### PR TITLE
DeviceInfo: Use config file for device specific settings.

### DIFF
--- a/src/utils/src/deviceinfo.cpp
+++ b/src/utils/src/deviceinfo.cpp
@@ -16,49 +16,43 @@
  */
 
 #include "deviceinfo.h"
+#include <QFile>
+
+const char* CONFIG_FILE = "/etc/asteroid/machine.conf";
+
+DeviceInfo::DeviceInfo()
+    : m_settings(CONFIG_FILE, QSettings::IniFormat)
+{
+    QSettings::Status status(m_settings.status());
+    if (status == QSettings::FormatError ) {
+        qWarning("Configuration file \"%s\" is in wrong format", CONFIG_FILE);
+    } else if (status != QSettings::NoError) {
+        qWarning("Unable to open \"%s\" configuration file", CONFIG_FILE);
+    }
+}
 
 bool DeviceInfo::hasRoundScreen()
 {
-#ifdef ROUND_SCREEN
-    return true;
-#else
-    return false;
-#endif
+    return m_settings.value("Display/ROUND", false).toBool();
 }
 
 double DeviceInfo::borderGestureWidth()
 {
-#ifdef BORDER_GESTURE_WIDTH
-    return BORDER_GESTURE_WIDTH;
-#else
-    return 0.1;
-#endif
+    return m_settings.value("Display/BORDER_GESTURE_WIDTH", 0.1).toFloat();
 }
 
 int DeviceInfo::flatTireHeight()
 {
-#ifdef FLAT_TIRE
-    return FLAT_TIRE;
-#else
-    return 0;
-#endif
+    return m_settings.value("Display/FLAT_TIRE", 0).toInt();
 }
 
 bool DeviceInfo::hasWlan()
 {
-#ifdef HAS_WLAN
-    return true;
-#else
-    return false;
-#endif
+    return m_settings.value("Capabilities/HAS_WLAN", false).toBool();
 }
 
 bool DeviceInfo::hasSpeaker()
 {
-#ifdef HAS_SPEAKER
-    return true;
-#else
-    return false;
-#endif
+    return m_settings.value("Capabilities/HAS_SPEAKER", false).toBool();
 }
 

--- a/src/utils/src/deviceinfo.h
+++ b/src/utils/src/deviceinfo.h
@@ -21,6 +21,7 @@
 #include <QObject>
 #include <QJSEngine>
 #include <QQmlEngine>
+#include <QSettings>
 
 class DeviceInfo : public QObject
 {
@@ -31,7 +32,7 @@ class DeviceInfo : public QObject
     Q_PROPERTY(int flatTireHeight READ flatTireHeight CONSTANT)
     Q_PROPERTY(bool hasWlan READ hasWlan CONSTANT)
     Q_PROPERTY(bool hasSpeaker READ hasSpeaker CONSTANT)
-    DeviceInfo() {}
+    DeviceInfo();
 public:
     static QObject *qmlInstance(QQmlEngine *engine, QJSEngine *scriptEngine)
     {
@@ -45,6 +46,8 @@ public:
     int flatTireHeight();
     bool hasWlan();
     bool hasSpeaker();
+private:
+    QSettings m_settings;
 };
 
 #endif // DEVICEINFO_H


### PR DESCRIPTION
Move away from using compile time watch specifics. Use a configuration file `machine.conf` if it is provided by a `meta-*-hybris` layer.

Main benefits:
- Won't have to compile `qml-asteroid` for every watch.
- Allows for configuration changes that aren't recommended (i.e. disable burn-in-protection on OLED displays).

I have created a `machine.conf` for `sturgeon` (https://github.com/AsteroidOS/meta-sturgeon-hybris/pull/13). Depending on changes required I will also adjust the other `hybris` layers when no more changes are required.