### PR TITLE
replaces Dims.dp with Dims.h in documentation

### DIFF
--- a/src/controls/qml/Dims.qml
+++ b/src/controls/qml/Dims.qml
@@ -45,7 +45,7 @@ pragma Singleton
 
    Rectangle {
        width: Dims.w(80) // 80 % of screen width
-       height: Dims.dp(50) // 50 % of screen height
+       height: Dims.h(50) // 50 % of screen height
 
        Label {
            text:"A"


### PR DESCRIPTION
Dims.dp is not defined in the code. Dims.h is and "... of screen height" + "Dims::h when you need a dimension relative to the height." implies that dp is outdated or a typo.