### PR TITLE
Adds FileInfo.

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,10 +1,12 @@
 set(SRC
 	src/utils_plugin.cpp
 	src/deviceinfo.cpp
+	src/fileinfo.cpp
 	src/bluetoothstatus.cpp)
 set(HEADERS
 	src/utils_plugin.h
 	src/deviceinfo.h
+	src/fileinfo.h
 	src/bluetoothstatus.h)
 
 add_library(asteroidutilsplugin ${SRC} ${HEADERS})

--- a/src/utils/src/fileinfo.cpp
+++ b/src/utils/src/fileinfo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 - Florent Revest <revestflo@gmail.com>
+ * Copyright (C) 2022 - Darrel Griët <dgriet@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -15,22 +15,14 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "utils_plugin.h"
-#include <QtQml>
-#include "bluetoothstatus.h"
-#include "deviceinfo.h"
 #include "fileinfo.h"
+#include <QFile>
+#include <QRegularExpression>
 
-UtilsPlugin::UtilsPlugin(QObject *parent) : QQmlExtensionPlugin(parent)
+bool FileInfo::exists(const QString fileName)
 {
+    QString file = QString(fileName);
+    file.replace(QRegularExpression("^file:\\/\\/"), "");
+    file.replace(QRegularExpression("^qrc:\\/"), ":/");
+    return QFile::exists(file);
 }
-
-void UtilsPlugin::registerTypes(const char *uri)
-{
-    Q_ASSERT(uri == QLatin1String("org.asteroid.utils"));
-
-    qmlRegisterSingletonType<DeviceInfo>(uri, 1,0, "DeviceInfo", &DeviceInfo::qmlInstance);
-    qmlRegisterSingletonType<FileInfo>(uri, 1, 0, "FileInfo", &FileInfo::qmlInstance);
-    qmlRegisterType<BluetoothStatus>(uri, 1, 0, "BluetoothStatus");
-}
-

--- a/src/utils/src/fileinfo.h
+++ b/src/utils/src/fileinfo.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 - Florent Revest <revestflo@gmail.com>
+ * Copyright (C) 2022 - Darrel Griët <dgriet@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -15,22 +15,27 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "utils_plugin.h"
-#include <QtQml>
-#include "bluetoothstatus.h"
-#include "deviceinfo.h"
-#include "fileinfo.h"
+#ifndef FILEINFO_H
+#define FILEINFO_H
 
-UtilsPlugin::UtilsPlugin(QObject *parent) : QQmlExtensionPlugin(parent)
+#include <QObject>
+#include <QJSEngine>
+#include <QQmlEngine>
+
+class FileInfo : public QObject
 {
-}
+    Q_OBJECT
+    Q_DISABLE_COPY(FileInfo)
+    FileInfo() {}
+public:
+    static QObject *qmlInstance(QQmlEngine *engine, QJSEngine *scriptEngine)
+    {
+        Q_UNUSED(engine);
+        Q_UNUSED(scriptEngine);
 
-void UtilsPlugin::registerTypes(const char *uri)
-{
-    Q_ASSERT(uri == QLatin1String("org.asteroid.utils"));
+        return new FileInfo;
+    }
+    Q_INVOKABLE bool exists(const QString fileName);
+};
 
-    qmlRegisterSingletonType<DeviceInfo>(uri, 1,0, "DeviceInfo", &DeviceInfo::qmlInstance);
-    qmlRegisterSingletonType<FileInfo>(uri, 1, 0, "FileInfo", &FileInfo::qmlInstance);
-    qmlRegisterType<BluetoothStatus>(uri, 1, 0, "BluetoothStatus");
-}
-
+#endif // FILEINFO_H


### PR DESCRIPTION
Provides a simple mechanism to check if a file exists or not.

This is part of the work done by @eLtMosen. (https://github.com/AsteroidOS/asteroid-settings/pull/39)

Prior to merging, I still would like to add support for file name patterns: `file://` and `qrc://`. Which basically is just replacing those with the pattern that `QFile` expects.