### PR TITLE
FlatMesh: Disable animation timer when invisible.

### DIFF
--- a/src/controls/src/flatmesh.cpp
+++ b/src/controls/src/flatmesh.cpp
@@ -40,8 +40,10 @@ FlatMesh::FlatMesh(QQuickItem *parent) : QQuickItem(parent)
     m_centerColor = QColor("#ffaa39");
     m_outerColor = QColor("#df4829");
 
+    connect(this, SIGNAL(visibleChanged()), this, SLOT(maybeEnableAnimation()));
+
     setFlag(ItemHasContents);
-    m_animated = true;
+    setAnimated(true);
 }
 
 void FlatMesh::setCenterColor(QColor c)
@@ -60,13 +62,23 @@ void FlatMesh::setOuterColor(QColor c)
     update();
 }
 
+void FlatMesh::maybeEnableAnimation()
+{
+    if (isVisible() && m_animated) {
+        m_timer.start();
+    } else {
+        m_timer.stop();
+    }
+    update();
+}
+
 void FlatMesh::setAnimated(bool animated)
 {
     if (animated == m_animated)
         return;
     m_animated = animated;
     emit animatedChanged();
-    update();
+    maybeEnableAnimation();
 }
 
 QSGNode *FlatMesh::updatePaintNode(QSGNode *old, UpdatePaintNodeData *)

--- a/src/controls/src/flatmesh.h
+++ b/src/controls/src/flatmesh.h
@@ -60,6 +60,9 @@ signals:
 protected:
     QSGNode *updatePaintNode(QSGNode *node, UpdatePaintNodeData *data);
 
+private slots:
+    void maybeEnableAnimation();
+
 private:
     QColor m_centerColor, m_outerColor;
     bool m_animated;


### PR DESCRIPTION
There's no point in updating the flatmesh when the animation has been disabled.
Additionally, disable the animation when the flatmesh isn't enabled.

This works nicely in conjunction with https://github.com/AsteroidOS/asteroid-launcher/pull/87.
It seems to reduce power usage when the FlatMesh is used as the wallpaper.