### PR TITLE
StatusPage: Adjust text margins to fit better on the screen.

### DIFF
--- a/src/controls/qml/StatusPage.qml
+++ b/src/controls/qml/StatusPage.qml
@@ -56,7 +56,7 @@ Item {
         verticalAlignment: Text.AlignVCenter
         wrapMode: Text.Wrap
         anchors.left: parent.left; anchors.right: parent.right
-        anchors.leftMargin: Dims.w(2); anchors.rightMargin: Dims.w(2)
+        anchors.leftMargin: Dims.w(4); anchors.rightMargin: anchors.leftMargin
         anchors.verticalCenter: parent.verticalCenter
         anchors.verticalCenterOffset: Dims.h(15)
     }


### PR DESCRIPTION
This adjusts the left and right margin so that it looks better on round watches.

This is a comparision of the previous and new look on round displays.

| Old | New |
|------|--------|
| ![nar-old-mar](https://user-images.githubusercontent.com/7857908/178146405-36d1891a-a183-460f-b170-9cb0ff368d03.jpg) | ![nar-mar](https://user-images.githubusercontent.com/7857908/178146401-a2b26ea5-b344-490e-8637-b85fe2c475cd.jpg) |

Here's a comparison on a rectangular display.

| Old | New |
|------|--------|
| ![bel_c1](https://user-images.githubusercontent.com/7857908/178146297-3b66b547-6bca-4caa-bc12-22a7efbf1d81.jpg) | ![bel_c2](https://user-images.githubusercontent.com/7857908/178146301-a3836166-6ca6-4510-8607-268f9d92fc18.jpg) |



