### PR TITLE
Layerstack respects changing 'firstpage'

### DIFF
--- a/src/controls/qml/LayerStack.qml
+++ b/src/controls/qml/LayerStack.qml
@@ -26,6 +26,7 @@ Item {
     property var firstPage
     property var layers: []
     property var currentLayer: layers.length > 0 ? layers[layers.length-1] : null
+    property var firstPageItem
     property QtObject win: parent  // Can be set to null if you don't want indicators animations and systemgestures override. If your LayerStack isn't directly a child element of your window, you can also specify the window via this parameter.
 
     Flickable {
@@ -56,8 +57,24 @@ Item {
         params["x"] = 0
         params["y"] = 0
         if(typeof firstPage != 'undefined' && firstPage.status === Component.Ready) {
-            var itm=firstPage.createObject(content, params)
-            itm.clip = true
+            firstPageItem=firstPage.createObject(content, params)
+            firstPageItem.clip = true
+        }
+    }
+
+    onFirstPageChanged: {
+        if(typeof firstPage != 'undefined') {
+            firstPageItem.destroy()
+            var params = {}
+            params["width"] = Qt.binding(function() { return width })
+            params["height"] =  Qt.binding(function() { return height })
+            params["x"] = 0
+            params["y"] = 0
+            firstPageItem=firstPage.createObject(content, params)
+            firstPageItem.clip = true
+            layersChanged()
+        } else {
+            console.log("LayerStack: firstpage has been updated with a null value")
         }
     }
 


### PR DESCRIPTION
The behaviour previously was that 'firstpage' was loaded in once when the item was initialised, and was then ignored. While this makes sense on some level, it severely complicates the development of more complex UIs. It also does not align with other Qt modules, where most properties will update live. This change makes the layerstack update when firstpage property is changed. 

Example:
An application needs the user to log in on the first run. If the dialog is pushed to the layerstack, then it can be dismissed by the user, which will lead to them seeing a UI that is not yet intended to be seen.
an alternative solution for this kind of issue would be to load in a much larger firstpage, which has invisible components that only become visible for the first run - however, these components will always be loaded even if they aren't used on subsequent runs.
Another solution would be to push another element on top of the existing layerstack, but this can lead to very messy code. If you wish to have layerstack navigation in the popup, it requires the creation of another layerstack, which really isn't necessary.