### PR TITLE
Update extra-cmake-modules syntax

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
 
 include(FeatureSummary)
 include(GNUInstallDirs)
-include(ECMQMLModules)
+include(ECMFindQmlModule)
 include(ECMGeneratePkgConfigFile)
 include(AsteroidCMakeSettings)
 


### PR DESCRIPTION
This is the complementary change to
https://github.com/AsteroidOS/meta-asteroid/pull/105

Signed-off-by: Ed Beroset <beroset@ieee.org>