### PR TITLE
Add PercentControl object

### DIFF
--- a/src/controls/qml/IntSelector.qml
+++ b/src/controls/qml/IntSelector.qml
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2022 - Ed Beroset <github.com/beroset>
+ * Copyright (C) 2020 - Darrel Griët <idanlcontact@gmail.com>
+ * Copyright (C) 2015 - Florent Revest <revestflo@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.9
+import org.asteroid.controls 1.0
+
+Row {
+    id: intSelector
+    // minimum allowed value
+    property int min: 0
+    // maximum allowed value
+    property int max: 100
+    // step size per button actuation
+    property int stepSize: 10
+    // unitMarker value appended to value display between buttons
+    property string unitMarker: "%"
+    // initial value of the control
+    property int value: 0
+    // labelWidthRatio is the width of the label with respect to the total width
+    property real labelWidthRatio: 0.42857
+    // fotToHeightRatio is the size of the font relative to the height
+    property real fontToHeightRatio: 0.3
+
+    height: parent.height
+    width: parent.width
+    IconButton { 
+        iconName: "ios-remove-circle-outline"
+        height: parent.height
+        width: height
+        onClicked: {
+            var newVal = value - stepSize
+            if(newVal < min) newVal = min
+            value = newVal
+        }
+    }
+
+    Label {
+        text: value + unitMarker
+        font.pixelSize: parent.height * fotToHeightRatio
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+        wrapMode: Text.Wrap
+        width: parent.width * labelWidthRatio
+        height: parent.height
+    }
+
+    IconButton {
+        iconName: "ios-add-circle-outline"
+        height: parent.height
+        width: height
+        onClicked: {
+            var newVal = value + stepSize
+            if(newVal > max) newVal = max
+            value = newVal
+        }
+    }
+}

--- a/src/controls/qmldir
+++ b/src/controls/qmldir
@@ -5,6 +5,7 @@ plugin asteroidcontrolsplugin
 CircularSpinner 1.0 qrc:///org/asteroid/controls/qml/CircularSpinner.qml
 PageDot 1.0 qrc:///org/asteroid/controls/qml/PageDot.qml
 PageHeader 1.0 qrc:///org/asteroid/controls/qml/PageHeader.qml
+IntSelector 1.0 qrc:///org/asteroid/controls/qml/IntSelector.qml
 LayerStack 1.0 qrc:///org/asteroid/controls/qml/LayerStack.qml
 Label 1.0 qrc:///org/asteroid/controls/qml/Label.qml
 Marquee 1.0 qrc:///org/asteroid/controls/qml/Marquee.qml

--- a/src/controls/resources.qrc
+++ b/src/controls/resources.qrc
@@ -12,6 +12,7 @@
         <file>qml/Marquee.qml</file>
         <file>qml/PageDot.qml</file>
         <file>qml/PageHeader.qml</file>
+        <file>qml/IntSelector.qml</file>
         <file>qml/SpinnerDelegate.qml</file>
         <file>qml/Spinner.qml</file>
         <file>qml/StatusPage.qml</file>


### PR DESCRIPTION
The PercentControl object is intended to be used for percentage settings, such as brightness or volume, but is written in a way that is intended to be generally useful.  It derives from the recent version of IconButton and has the following settable properties:

min - an integer describing the minimum value (default: 0) max - an integer describing the maximum value (default: 100) stepsize - an integer step size (default: 10)
marker - a string appended to the value display (default: "%") value - an integer representing the initial value (default: 0) multiplier - a real representing the portion of the width used for the label between the two icons (default 0.42857 to match existing ratios) fontratio - a real representing the ratio of font size to height (default: 0.3 to match existing ratios)

Signed-off-by: Ed Beroset <beroset@ieee.org>