### PR TITLE
Add a LabeledSwitch control

### DIFF
--- a/src/controls/qml/LabeledSwitch.qml
+++ b/src/controls/qml/LabeledSwitch.qml
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 - Ed Beroset <github.com/beroset>
+ * Copyright (C) 2020 - Darrel Griët <idanlcontact@gmail.com>
+ * Copyright (C) 2015 - Florent Revest <revestflo@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.9
+import org.asteroid.controls 1.0
+
+Row {
+    // labelWidthRatio is the ratio of label width to the total width
+    property real labelWidthRatio: 0.7143
+    // fontToHeightRatio is the ratio of the font size to the height
+    property real fontToHeightRatio: 0.3
+    property alias checked: toggle.checked
+    property alias text: label.text
+
+    height: parent.height
+    width: parent.width
+
+    Label {
+        id: label
+        text: value
+        font.pixelSize: parent.height * fontToHeightRatio
+        verticalAlignment: Text.AlignVCenter
+        wrapMode: Text.Wrap
+        width: parent.width * labelWidthRatio
+        height: parent.height
+    }
+
+    Switch {
+        id: toggle
+        height: parent.height
+        width: height
+    }
+}

--- a/src/controls/qmldir
+++ b/src/controls/qmldir
@@ -8,6 +8,7 @@ PageHeader 1.0 qrc:///org/asteroid/controls/qml/PageHeader.qml
 LayerStack 1.0 qrc:///org/asteroid/controls/qml/LayerStack.qml
 Label 1.0 qrc:///org/asteroid/controls/qml/Label.qml
 Marquee 1.0 qrc:///org/asteroid/controls/qml/Marquee.qml
+LabeledSwitch 1.0 qrc:///org/asteroid/controls/qml/LabeledSwitch.qml
 Application 1.0 qrc:///org/asteroid/controls/qml/Application.qml
 BorderGestureArea 1.0 qrc:///org/asteroid/controls/qml/BorderGestureArea.qml
 IconButton 1.0 qrc:///org/asteroid/controls/qml/IconButton.qml

--- a/src/controls/resources.qrc
+++ b/src/controls/resources.qrc
@@ -10,6 +10,7 @@
         <file>qml/Label.qml</file>
         <file>qml/LayerStack.qml</file>
         <file>qml/Marquee.qml</file>
+        <file>qml/LabeledSwitch.qml</file>
         <file>qml/PageDot.qml</file>
         <file>qml/PageHeader.qml</file>
         <file>qml/SpinnerDelegate.qml</file>


### PR DESCRIPTION
This adds a LabeledSwitch control to simplify and standardize many of the settings pages.  It has four properties:

multiplier - a real representing the portion of the width used for the
    label to the left of the switch (default 0.7143 to match existing ratios)
fontratio - a real representing the ratio of font size to height
    (default: 0.3 to match existing ratios)
checked - a bool
text - a string for the label to the left of the switch

Signed-off-by: Ed Beroset <beroset@ieee.org>