### PR TITLE
Use dims as default size for intselector and labeledswitch controls

### DIFF
--- a/src/controls/qml/IntSelector.qml
+++ b/src/controls/qml/IntSelector.qml
@@ -37,8 +37,6 @@ Row {
     // fontToHeightRatio is the size of the font relative to the height
     property real fontToHeightRatio: 0.3
 
-    height: parent.height
-    width: parent.width
     IconButton { 
         iconName: "ios-remove-circle-outline"
         height: parent.height

--- a/src/controls/qml/LabeledSwitch.qml
+++ b/src/controls/qml/LabeledSwitch.qml
@@ -28,9 +28,6 @@ Row {
     property alias checked: toggle.checked
     property alias text: label.text
 
-    height: parent.height
-    width: parent.width
-
     Label {
         id: label
         text: value


### PR DESCRIPTION
QML extension components seem to generally use absolute pixel values (in our case, the equivalent being dims) as default values. The way these are currently set up causes them to behave inconsistently in columns and rows, requiring workarounds to get them to work correctly. This commit brings them in line with other controls in qml-asteroid.