### PR TITLE
Center indicators in window on flat tyre watches

### DIFF
--- a/src/controls/qml/Application.qml
+++ b/src/controls/qml/Application.qml
@@ -18,6 +18,7 @@
 
 import QtQuick 2.9
 import org.asteroid.controls 1.0
+import org.asteroid.utils 1.0
 
 Application_p {
     anchors.fill: parent
@@ -47,6 +48,7 @@ Application_p {
         edge: Qt.RightEdge
         visible: false
         z: 10
+        anchors.verticalCenterOffset: DeviceInfo.flatTireHeight/2
     }
 
     Indicator {
@@ -54,6 +56,7 @@ Application_p {
         edge: Qt.LeftEdge
         visible: true
         z: 10
+        anchors.verticalCenterOffset: DeviceInfo.flatTireHeight/2
     }
 
     Indicator {


### PR DESCRIPTION
the left and right indicators previously appeared at the window center, which does not align with the visual center of the display. This moves them down by half the flat tyre height to compensate.

This only fixes the indicators in the window element. This does not affect all indicators everywhere.
After thinking about the flat tyre problem for a very long time, I came to the conclusion that it should be compensated for on a case-by-case basis. Developers already have access to the raw flat tyre height, so small changes like these will be needed everywhere to make this work. 