### PR TITLE
Create desktop modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ find_package(ECM REQUIRED NO_MODULE)
 
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
 
+option(WITH_ASTEROIDAPP "Build the AsteroidApp class" ON)
+option(WITH_CMAKE_MODULES "Install AsteroidOS CMake modules" ON)
+
 include(FeatureSummary)
 include(GNUInstallDirs)
 include(ECMFindQmlModule)
@@ -17,19 +20,34 @@ include(AsteroidCMakeSettings)
 set(ASTEROID_MODULES_INSTALL_DIR ${CMAKE_INSTALL_DATADIR}/asteroidapp/cmake)
 
 find_package(Qt5 ${QT_MIN_VERSION} COMPONENTS DBus Qml Quick Svg REQUIRED)
-find_package(Mlite5 MODULE REQUIRED)
-find_package(Mapplauncherd_qt5 MODULE REQUIRED)
+if (WITH_ASTEROIDAPP)
+    find_package(Mlite5 MODULE REQUIRED)
+    find_package(Mapplauncherd_qt5 MODULE REQUIRED)
+endif()
 
 ecm_find_qmlmodule(QtQuick.VirtualKeyboard 2.1)
 
+if (WITH_CMAKE_MODULES)
+# Install CMake modules
+    file(GLOB installAsteroidModuleFiles LIST_DIRECTORIES FALSE ${CMAKE_SOURCE_DIR}/cmake/*[^~])
+    install(FILES ${installAsteroidModuleFiles} DESTINATION ${ASTEROID_MODULES_INSTALL_DIR})
+else()
+    get_target_property(REAL_QMAKE_EXECUTABLE Qt::qmake IMPORTED_LOCATION)
+
+    if (NOT QT_INSTALL_QML)
+        execute_process(COMMAND "${REAL_QMAKE_EXECUTABLE}" -query QT_INSTALL_QML
+                        OUTPUT_VARIABLE QT_INSTALL_QML
+                        ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    endif()
+    set(INSTALL_QML_IMPORT_DIR ${QT_INSTALL_QML})
+endif()
+
 add_subdirectory(src)
 
-# Install CMake modules
-file(GLOB installAsteroidModuleFiles LIST_DIRECTORIES FALSE ${CMAKE_SOURCE_DIR}/cmake/*[^~])
-install(FILES ${installAsteroidModuleFiles} DESTINATION ${ASTEROID_MODULES_INSTALL_DIR})
-
-install(PROGRAMS generate-desktop.sh
-	DESTINATION ${CMAKE_INSTALL_BINDIR}
-	RENAME asteroid-generate-desktop)
+if (WITH_ASTEROIDAPP)
+    install(PROGRAMS generate-desktop.sh
+            DESTINATION ${CMAKE_INSTALL_BINDIR}
+            RENAME asteroid-generate-desktop)
+endif() 
 
 feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
 # QML Components for Asteroid
 
 QML-Asteroid provides elements to develop applications for [AsteroidOS](http://asteroidos.org).
+
+## Non-watch version
+It's often convenient to develop on a desktop computer rather than directly on the watch.  For that reason, `qml-asteroid` also supports building a non-watch version.  To build and install it on a desktop computer, one can turn off the generation of the AsteroidApp class and the installation of CMake modules.  For example, in the project's main directory, we might execute this command:
+
+```
+cmake -DWITH_ASTEROIDAPP=OFF -DWITH_CMAKE_MODULES=OFF -S . -B desktop
+```
+
+This will create a directory `desktop` which will then contain all of the CMake-generated build scripts.  To build the modules:
+
+```
+cmake --build desktop -j
+```
+
+This tells CMake to build in the `desktop` directory and the `-j` tells it to use as many cores as possible to speed up the build.  Once this is done, one can install the modules on the computer:
+
+```
+sudo cmake --build desktop -j -t install
+```
+
+This uses `sudo` because root privileges are generally needed for installation.  The `-t install` tells CMake that the build target (that is, the goal) is `install` so the `org.asteroid.controls` and `org.asteroid.utils` QML modules will be installed in the correct location for the computer and may then be used, for example, in testing and developing watchfaces.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
-add_subdirectory(app)
+if (WITH_ASTEROIDAPP)
+    add_subdirectory(app)
+endif()
 add_subdirectory(controls)
 add_subdirectory(utils)

--- a/src/utils/src/deviceinfo.cpp
+++ b/src/utils/src/deviceinfo.cpp
@@ -45,7 +45,7 @@ DeviceInfo::DeviceInfo()
         QTextStream in(&release);
         in.setCodec("UTF-8");
         QString line = in.readLine();
-        for (bool searching{true}; searching; line = in.readLine()) {
+        for (bool searching{true}; searching && !in.atEnd(); line = in.readLine()) {
             if (line.startsWith("BUILD_ID")) {
                 auto parts = line.split(QLatin1Char('='));
                 m_buildid = parts[1];


### PR DESCRIPTION
This adds support for building, installing and running org.asteroid.controls and org.asteroid.utils on a desktop development machine, allowing for easier development and testing of watchfaces on a desktop Linux machine.  This fixes https://github.com/AsteroidOS/unofficial-watchfaces/issues/37