### PR TITLE
Unify settings pages components

### DIFF
--- a/src/controls/qml/HighlightBar.qml
+++ b/src/controls/qml/HighlightBar.qml
@@ -22,7 +22,9 @@ import QtQuick 2.9
 import org.asteroid.controls 1.0
 
 Rectangle {
+    // onClicked dummy function can be overridden by caller
     property var onClicked: function(){}
+    // alias to recieve boolean forceOn to act like a controlled radio button
     property bool forceOn: false
 
     anchors.fill: parent

--- a/src/controls/qml/HighlightBar.qml
+++ b/src/controls/qml/HighlightBar.qml
@@ -22,9 +22,9 @@ import QtQuick 2.9
 import org.asteroid.controls 1.0
 
 Rectangle {
-    // onClicked dummy function can be overridden by caller
-    property var onClicked: function(){}
-    // alias to recieve boolean forceOn to act like a controlled radio button
+    // forward the clicked() signal to parent
+    signal clicked()
+    // alias to receive boolean forceOn to act like a controlled radio button
     property bool forceOn: false
 
     anchors.fill: parent
@@ -42,8 +42,6 @@ Rectangle {
 
         anchors.fill: parent
         hoverEnabled: true
-        onClicked: {
-            parent.onClicked()
-        }
+        onClicked: parent.clicked()
     }
 }

--- a/src/controls/qml/HighlightBar.qml
+++ b/src/controls/qml/HighlightBar.qml
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
+ * Copyright (C) 2022 - Ed Beroset <github.com/beroset>
+ * Copyright (C) 2020 - Darrel Griët <idanlcontact@gmail.com>
+ * Copyright (C) 2015 - Florent Revest <revestflo@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.9
+import org.asteroid.controls 1.0
+
+Rectangle {
+    property var onClicked: function(){}
+    property bool forceOn: false
+
+    anchors.fill: parent
+    color: rowClick.containsPress || forceOn ? "#33ffffff" : "#00ffffff"
+
+    Behavior on color {
+        ColorAnimation {
+            duration: 150;
+            easing.type: Easing.OutQuad
+        }
+    }
+
+    MouseArea {
+        id: rowClick
+
+        anchors.fill: parent
+        hoverEnabled: true
+        onClicked: {
+            parent.onClicked()
+        }
+    }
+}

--- a/src/controls/qml/IntSelector.qml
+++ b/src/controls/qml/IntSelector.qml
@@ -32,6 +32,12 @@ Item {
     property string unitMarker: "%"
     // initial value of the control
     property int value: 0
+    // left and right margin for the row content
+    property int rowMargin: Dims.w(15)
+    // size of the icon/s
+    property int iconSize: Dims.l(20)
+    // size of the label text
+    property int labelFontSize: Dims.l(6)
 
     width: parent.width
     height: parent.height
@@ -42,10 +48,10 @@ Item {
         iconName: "ios-remove-circle-outline"
         anchors {
             left: parent.left
-            leftMargin: Dims.w(15)
+            leftMargin: rowMargin
             verticalCenter: parent.verticalCenter
         }
-        height: Dims.h(20)
+        height: iconSize
         width: height
         onClicked: {
             var newVal = value - stepSize
@@ -60,7 +66,7 @@ Item {
             left: buttonLeft.right
             right: buttonRight.left
         }
-        font.pixelSize: Dims.l(6)
+        font.pixelSize: labelFontSize
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
         wrapMode: Text.Wrap
@@ -74,10 +80,10 @@ Item {
         iconName: "ios-add-circle-outline"
         anchors {
             right: parent.right
-            rightMargin: Dims.w(15)
+            rightMargin: rowMargin
             verticalCenter: parent.verticalCenter
         }
-        height: Dims.h(20)
+        height: iconSize
         width: height
         onClicked: {
             var newVal = value + stepSize

--- a/src/controls/qml/IntSelector.qml
+++ b/src/controls/qml/IntSelector.qml
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
  * Copyright (C) 2022 - Ed Beroset <github.com/beroset>
  * Copyright (C) 2020 - Darrel Griët <idanlcontact@gmail.com>
  * Copyright (C) 2015 - Florent Revest <revestflo@gmail.com>
@@ -20,8 +21,7 @@
 import QtQuick 2.9
 import org.asteroid.controls 1.0
 
-Row {
-    id: intSelector
+Item {
     // minimum allowed value
     property int min: 0
     // maximum allowed value
@@ -32,14 +32,20 @@ Row {
     property string unitMarker: "%"
     // initial value of the control
     property int value: 0
-    // labelWidthRatio is the width of the label with respect to the total width
-    property real labelWidthRatio: 0.42857
-    // fontToHeightRatio is the size of the font relative to the height
-    property real fontToHeightRatio: 0.3
 
-    IconButton { 
+    width: parent.width
+    height: parent.height
+
+    IconButton {
+        id: buttonLeft
+
         iconName: "ios-remove-circle-outline"
-        height: parent.height
+        anchors {
+            left: parent.left
+            leftMargin: Dims.w(15)
+            verticalCenter: parent.verticalCenter
+        }
+        height: Dims.h(20)
         width: height
         onClicked: {
             var newVal = value - stepSize
@@ -50,7 +56,11 @@ Row {
 
     Label {
         text: value + unitMarker
-        font.pixelSize: parent.height * fontToHeightRatio
+        anchors {
+            left: buttonLeft.right
+            right: buttonRight.left
+        }
+        font.pixelSize: Dims.l(6)
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
         wrapMode: Text.Wrap
@@ -59,8 +69,15 @@ Row {
     }
 
     IconButton {
+        id: buttonRight
+
         iconName: "ios-add-circle-outline"
-        height: parent.height
+        anchors {
+            right: parent.right
+            rightMargin: Dims.w(15)
+            verticalCenter: parent.verticalCenter
+        }
+        height: Dims.h(20)
         width: height
         onClicked: {
             var newVal = value + stepSize

--- a/src/controls/qml/LabeledActionButton.qml
+++ b/src/controls/qml/LabeledActionButton.qml
@@ -22,8 +22,17 @@ import QtQuick 2.9
 import org.asteroid.controls 1.0
 
 Item {
+    // alias to recieve string icon.name
     property alias icon: icon.name
+    // alias to recieve string label.text
     property alias text: label.text
+    // left and right margin for the row content
+    property int rowMargin: Dims.w(15)
+    // size of the icon/s
+    property int iconSize: Dims.l(20)
+    // size of the label text
+    property int labelFontSize: Dims.l(6)
+    // onClicked dummy function can be overridden by caller
     property var onClicked: function(){}
 
     width: parent.width
@@ -38,11 +47,11 @@ Item {
 
         anchors {
             left: parent.left
-            leftMargin: Dims.w(15)
+            leftMargin: rowMargin
             right: icon.left
         }
         text: value
-        font.pixelSize: Dims.l(6)
+        font.pixelSize: labelFontSize
         verticalAlignment: Text.AlignVCenter
         wrapMode: Text.Wrap
         height: parent.height
@@ -53,10 +62,10 @@ Item {
 
         anchors {
             right: parent.right
-            rightMargin: Dims.w(15)
+            rightMargin: rowMargin
             verticalCenter: parent.verticalCenter
         }
-        height: Dims.w(20)
+        height: iconSize
         width: height
     }
 }

--- a/src/controls/qml/LabeledActionButton.qml
+++ b/src/controls/qml/LabeledActionButton.qml
@@ -22,9 +22,9 @@ import QtQuick 2.9
 import org.asteroid.controls 1.0
 
 Item {
-    // alias to recieve string icon.name
+    // alias to receive string icon.name
     property alias icon: icon.name
-    // alias to recieve string label.text
+    // alias to receive string label.text
     property alias text: label.text
     // left and right margin for the row content
     property int rowMargin: Dims.w(15)
@@ -38,6 +38,13 @@ Item {
     width: parent.width
     height: parent.height
 
+    Behavior on opacity {
+        NumberAnimation {
+            duration: 200;
+            easing.type: Easing.OutQuad
+        }
+    }
+
     HighlightBar {
         onClicked: function() { parent.onClicked() }
     }
@@ -49,6 +56,7 @@ Item {
             left: parent.left
             leftMargin: rowMargin
             right: icon.left
+            rightMargin: Dims.h(4)
         }
         text: value
         font.pixelSize: labelFontSize

--- a/src/controls/qml/LabeledActionButton.qml
+++ b/src/controls/qml/LabeledActionButton.qml
@@ -32,8 +32,8 @@ Item {
     property int iconSize: Dims.l(20)
     // size of the label text
     property int labelFontSize: Dims.l(6)
-    // onClicked dummy function can be overridden by caller
-    property var onClicked: function(){}
+    // forward the clicked() signal to parent
+    signal clicked()
 
     width: parent.width
     height: parent.height
@@ -46,7 +46,7 @@ Item {
     }
 
     HighlightBar {
-        onClicked: function() { parent.onClicked() }
+        onClicked: parent.onClicked()
     }
 
     Label {

--- a/src/controls/qml/LabeledActionButton.qml
+++ b/src/controls/qml/LabeledActionButton.qml
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
+ * Copyright (C) 2022 - Ed Beroset <github.com/beroset>
+ * Copyright (C) 2020 - Darrel Griët <idanlcontact@gmail.com>
+ * Copyright (C) 2015 - Florent Revest <revestflo@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.9
+import org.asteroid.controls 1.0
+
+Item {
+    property alias icon: icon.name
+    property alias text: label.text
+    property var onClicked: function(){}
+
+    width: parent.width
+    height: parent.height
+
+    HighlightBar {
+        onClicked: function() { parent.onClicked() }
+    }
+
+    Label {
+        id: label
+
+        anchors {
+            left: parent.left
+            leftMargin: Dims.w(15)
+            right: icon.left
+        }
+        text: value
+        font.pixelSize: Dims.l(6)
+        verticalAlignment: Text.AlignVCenter
+        wrapMode: Text.Wrap
+        height: parent.height
+    }
+
+    Icon {
+        id: icon
+
+        anchors {
+            right: parent.right
+            rightMargin: Dims.w(15)
+            verticalCenter: parent.verticalCenter
+        }
+        height: Dims.w(20)
+        width: height
+    }
+}

--- a/src/controls/qml/LabeledSwitch.qml
+++ b/src/controls/qml/LabeledSwitch.qml
@@ -22,8 +22,16 @@ import QtQuick 2.9
 import org.asteroid.controls 1.0
 
 Item {
+    // alias to recieve string toggle.checked
     property alias checked: toggle.checked
+    // alias to recieve string label.text
     property alias text: label.text
+    // left and right margin for the row content
+    property int rowMargin: Dims.w(15)
+    // size of the icon/s
+    property int iconSize: Dims.l(20)
+    // size of the label text
+    property int labelFontSize: Dims.l(6)
 
     width: parent.width
     height: parent.height
@@ -33,11 +41,11 @@ Item {
 
         anchors {
             left: parent.left
-            leftMargin: Dims.w(15)
+            leftMargin: rowMargin
             right: toggle.left
         }
         text: value
-        font.pixelSize: Dims.l(6)
+        font.pixelSize: labelFontSize
         verticalAlignment: Text.AlignVCenter
         wrapMode: Text.Wrap
         height: parent.height
@@ -48,10 +56,10 @@ Item {
 
         anchors {
             right: parent.right
-            rightMargin: Dims.w(15)
+            rightMargin: rowMargin
             verticalCenter: parent.verticalCenter
         }
-        height: Dims.w(20)
+        height: iconSize
         width: height
     }
 

--- a/src/controls/qml/LabeledSwitch.qml
+++ b/src/controls/qml/LabeledSwitch.qml
@@ -1,4 +1,5 @@
 /*
+ * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
  * Copyright (C) 2022 - Ed Beroset <github.com/beroset>
  * Copyright (C) 2020 - Darrel Griët <idanlcontact@gmail.com>
  * Copyright (C) 2015 - Florent Revest <revestflo@gmail.com>
@@ -20,27 +21,41 @@
 import QtQuick 2.9
 import org.asteroid.controls 1.0
 
-Row {
-    // labelWidthRatio is the ratio of label width to the total width
-    property real labelWidthRatio: 0.7143
-    // fontToHeightRatio is the ratio of the font size to the height
-    property real fontToHeightRatio: 0.3
+Item {
     property alias checked: toggle.checked
     property alias text: label.text
 
+    width: parent.width
+    height: parent.height
+
     Label {
         id: label
+
+        anchors {
+            left: parent.left
+            leftMargin: Dims.w(15)
+            right: toggle.left
+        }
         text: value
-        font.pixelSize: parent.height * fontToHeightRatio
+        font.pixelSize: Dims.l(6)
         verticalAlignment: Text.AlignVCenter
         wrapMode: Text.Wrap
-        width: parent.width * labelWidthRatio
         height: parent.height
     }
 
     Switch {
         id: toggle
-        height: parent.height
+
+        anchors {
+            right: parent.right
+            rightMargin: Dims.w(15)
+            verticalCenter: parent.verticalCenter
+        }
+        height: Dims.w(20)
         width: height
+    }
+
+    HighlightBar {
+        onClicked: function() {toggle.checked = !toggle.checked}
     }
 }

--- a/src/controls/qml/LabeledSwitch.qml
+++ b/src/controls/qml/LabeledSwitch.qml
@@ -72,6 +72,6 @@ Item {
     }
 
     HighlightBar {
-        onClicked: function() {toggle.checked = !toggle.checked}
+        onClicked: toggle.checked = !toggle.checked
     }
 }

--- a/src/controls/qml/LabeledSwitch.qml
+++ b/src/controls/qml/LabeledSwitch.qml
@@ -22,9 +22,9 @@ import QtQuick 2.9
 import org.asteroid.controls 1.0
 
 Item {
-    // alias to recieve string toggle.checked
+    // alias to receive string toggle.checked
     property alias checked: toggle.checked
-    // alias to recieve string label.text
+    // alias to receive string label.text
     property alias text: label.text
     // left and right margin for the row content
     property int rowMargin: Dims.w(15)
@@ -36,6 +36,13 @@ Item {
     width: parent.width
     height: parent.height
 
+    Behavior on opacity {
+        NumberAnimation {
+            duration: 200;
+            easing.type: Easing.OutQuad
+        }
+    }
+
     Label {
         id: label
 
@@ -43,6 +50,7 @@ Item {
             left: parent.left
             leftMargin: rowMargin
             right: toggle.left
+            rightMargin: Dims.h(4)
         }
         text: value
         font.pixelSize: labelFontSize

--- a/src/controls/qml/ListItem.qml
+++ b/src/controls/qml/ListItem.qml
@@ -40,7 +40,7 @@ Item {
     HighlightBar {
         id: highlight
 
-        onClicked: function() { parent.clicked() }
+        onClicked: parent.clicked()
     }
 
     Icon {

--- a/src/controls/qml/ListItem.qml
+++ b/src/controls/qml/ListItem.qml
@@ -21,9 +21,17 @@ import org.asteroid.controls 1.0
 import org.asteroid.utils 1.0
 
 Item {
+    // alias to recieve string label.text
     property alias title: label.text
+    // alias to recieve string icon.name
     property alias iconName: icon.name
+    // alias to recieve boolean highlight.forceOn
     property alias highlight: highlight.forceOn
+    // size of the icon/s
+    property int iconSize: height - Dims.h(6)
+    // size of the label text
+    property int labelFontSize: Dims.l(9)
+    // forward the clicked() signal to parent
     signal clicked()
 
     width: parent.width
@@ -38,7 +46,7 @@ Item {
     Icon {
         id: icon
 
-        width: parent.height - Dims.h(6)
+        width: iconSize
         height: width
 
         anchors {
@@ -57,7 +65,7 @@ Item {
             verticalCenter: parent.verticalCenter
         }
         font {
-            pixelSize: Dims.l(9)
+            pixelSize: labelFontSize
             styleName: "SemiCondensed Light"
         }
     }

--- a/src/controls/qml/ListItem.qml
+++ b/src/controls/qml/ListItem.qml
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
+ *               2015 - Florent Revest <revestflo@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.9
+import org.asteroid.controls 1.0
+import org.asteroid.utils 1.0
+
+Item {
+    property alias title: label.text
+    property alias iconName: icon.name
+    property alias highlight: highlight.forceOn
+    signal clicked()
+
+    width: parent.width
+    height: Dims.h(21)
+
+    HighlightBar {
+        id: highlight
+
+        onClicked: function() { parent.clicked() }
+    }
+
+    Icon {
+        id: icon
+
+        width: parent.height - Dims.h(6)
+        height: width
+
+        anchors {
+            verticalCenter: parent.verticalCenter
+            left: parent.left
+            leftMargin: DeviceInfo.hasRoundScreen ? Dims.w(18) : Dims.w(12)
+        }
+    }
+
+    Label {
+        id: label
+
+        anchors {
+            leftMargin: DeviceInfo.hasRoundScreen ? Dims.w(6) : Dims.w(10)
+            left: icon.right
+            verticalCenter: parent.verticalCenter
+        }
+        font {
+            pixelSize: Dims.l(9)
+            styleName: "SemiCondensed Light"
+        }
+    }
+}

--- a/src/controls/qmldir
+++ b/src/controls/qmldir
@@ -6,10 +6,13 @@ CircularSpinner 1.0 qrc:///org/asteroid/controls/qml/CircularSpinner.qml
 PageDot 1.0 qrc:///org/asteroid/controls/qml/PageDot.qml
 PageHeader 1.0 qrc:///org/asteroid/controls/qml/PageHeader.qml
 IntSelector 1.0 qrc:///org/asteroid/controls/qml/IntSelector.qml
+HighlightBar 1.0 qrc:///org/asteroid/controls/qml/HighlightBar.qml
 LayerStack 1.0 qrc:///org/asteroid/controls/qml/LayerStack.qml
 Label 1.0 qrc:///org/asteroid/controls/qml/Label.qml
 Marquee 1.0 qrc:///org/asteroid/controls/qml/Marquee.qml
 LabeledSwitch 1.0 qrc:///org/asteroid/controls/qml/LabeledSwitch.qml
+ListItem 1.0 qrc:///org/asteroid/controls/qml/ListItem.qml
+LabeledActionButton 1.0 qrc:///org/asteroid/controls/qml/LabeledActionButton.qml
 Application 1.0 qrc:///org/asteroid/controls/qml/Application.qml
 BorderGestureArea 1.0 qrc:///org/asteroid/controls/qml/BorderGestureArea.qml
 IconButton 1.0 qrc:///org/asteroid/controls/qml/IconButton.qml

--- a/src/controls/resources.qrc
+++ b/src/controls/resources.qrc
@@ -4,13 +4,16 @@
         <file>qml/BorderGestureArea.qml</file>
         <file>qml/CircularSpinner.qml</file>
         <file>qml/Dims.qml</file>
+        <file>qml/ListItem.qml</file>
         <file>qml/HandWritingKeyboard.qml</file>
+        <file>qml/HighlightBar.qml</file>
         <file>qml/IconButton.qml</file>
         <file>qml/Indicator.qml</file>
         <file>qml/Label.qml</file>
         <file>qml/LayerStack.qml</file>
         <file>qml/Marquee.qml</file>
         <file>qml/LabeledSwitch.qml</file>
+        <file>qml/LabeledActionButton.qml</file>
         <file>qml/PageDot.qml</file>
         <file>qml/PageHeader.qml</file>
         <file>qml/IntSelector.qml</file>


### PR DESCRIPTION
Unifiy the layouts of the components used on the settings pages to fixed font and icon size.
Give horizontal spacing/margin within the component so the full width of the screen can be used and must not be limited by margins given in the settings pages.

- Move ListItem from asteroid-settings
- Add LabeledActionButton analog to LabeledSwitch
- Add HighlightBar used in LabeledSwitch
- Refactor LabeledSwitch to fixed Dims.h(20) icon height and Dims.h(25) rowHeight
- Refactor IntSelector to fixed Dims.h(20) icon height and Dims.h(25) rowHeight
- Update qmldir and resource.qrc with new components
