### PR TITLE
Add doc target for build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,16 @@ endif()
 
 add_subdirectory(src)
 
+add_custom_target(
+    doc
+    DEPENDS "${CMAKE_BINARY_DIR}/doc/html/qml-dims.html"
+)
+add_custom_command(
+    OUTPUT  "${CMAKE_BINARY_DIR}/doc/html/qml-dims.html"
+    COMMAND "qdoc" "-indexdir" "/usr/share/doc/qt5" "-outputdir" "${CMAKE_BINARY_DIR}/doc/html" "${CMAKE_CURRENT_SOURCE_DIR}/src/controls/doc/asteroid_controls.qdocconf"
+    COMMENT "Generating HTML format Reference documentation..." VERBATIM
+)
+
 if (WITH_ASTEROIDAPP)
     install(PROGRAMS generate-desktop.sh
             DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/controls/doc/asteroid_controls.qdocconf
+++ b/src/controls/doc/asteroid_controls.qdocconf
@@ -2,7 +2,6 @@ project     = AsteroidControls
 description = Asteroid Controls Documentation
 
 outputformats = HTML
-outputdir     = html
 
 depends = qtqml qtquick qtwidgets qtdoc qtquicklayouts
 


### PR DESCRIPTION
This adds a "doc" target for the CMake file so that HTML documentation for the controls is built in "doc/html".