### PR TITLE
Fix layerstack destroy error

### DIFF
--- a/src/controls/qml/LayerStack.qml
+++ b/src/controls/qml/LayerStack.qml
@@ -64,7 +64,9 @@ Item {
 
     onFirstPageChanged: {
         if(typeof firstPage != 'undefined') {
-            firstPageItem.destroy()
+            if (firstPageItem) {
+                firstPageItem.destroy()
+            }
             while (layers.length > 0) {
                 pop(currentLayer)
             }

--- a/src/controls/qml/LayerStack.qml
+++ b/src/controls/qml/LayerStack.qml
@@ -50,18 +50,6 @@ Item {
         ScriptAction { script: if(win !== null) win.animIndicators() }
     }
 
-    Component.onCompleted: {
-        var params = {}
-        params["width"] = Qt.binding(function() { return width })
-        params["height"] =  Qt.binding(function() { return height })
-        params["x"] = 0
-        params["y"] = 0
-        if(typeof firstPage != 'undefined' && firstPage.status === Component.Ready) {
-            firstPageItem=firstPage.createObject(content, params)
-            firstPageItem.clip = true
-        }
-    }
-
     onFirstPageChanged: {
         if(typeof firstPage != 'undefined') {
             if (firstPageItem) {
@@ -75,9 +63,11 @@ Item {
             params["height"] =  Qt.binding(function() { return height })
             params["x"] = 0
             params["y"] = 0
-            firstPageItem=firstPage.createObject(content, params)
-            firstPageItem.clip = true
-            layersChanged()
+            if(typeof firstPage != 'undefined' && firstPage.status === Component.Ready) {
+                firstPageItem=firstPage.createObject(content, params)
+                firstPageItem.clip = true
+                layersChanged()
+            }
         } else {
             console.log("LayerStack: firstpage has been updated with a null value")
         }


### PR DESCRIPTION
This fixes a non-fatal error introduced by me in ed6d164f897c57d24520580c78b5a4f6d409ce04 that caused significant log spam.
Errors would show up like this:
```
TypeError: Cannot call method 'destroy' of undefined
```
This would happen because the code tried to destroy the firstPage before it had even been created. A simple check of whether firstPageItem exists is all that was needed here. 

This also copies the safety check to onFirstPageChanged, and removes component.onCompleted, since the two functions are redundant and are both called in the creation process. 