### PR TITLE
Redesign PageHeader component

### DIFF
--- a/src/controls/qml/PageHeader.qml
+++ b/src/controls/qml/PageHeader.qml
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2017 Florent Revest <revestflo@gmail.com>
+ * Copyright (C) 2023 - Timo Könnecke <github.com/eLtMosen>
+ * Copyright (C) 2017 - Florent Revest <revestflo@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -19,18 +20,40 @@ import QtQuick 2.9
 import org.asteroid.controls 1.0
 import org.asteroid.utils 1.0
 
-Label {
-    height: Dims.h(20)
-    font.pixelSize: Dims.l(6)
-    font.capitalization: Font.SmallCaps
-    anchors.top: parent.top
-    anchors.left: parent.left
-    anchors.right: parent.right
-    verticalAlignment: Text.AlignVCenter
-    horizontalAlignment: Text.AlignHCenter
-    leftPadding: DeviceInfo.hasRoundScreen ? Dims.w(25) : 0
-    rightPadding: DeviceInfo.hasRoundScreen ? Dims.w(25) : 0
-    wrapMode: Text.WordWrap
-    maximumLineCount: 2
-}
+Item {
 
+    property alias text: title.text
+
+    height: Dims.h(20)
+    anchors {
+        top: parent.top
+        left: parent.left
+        right: parent.right
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        gradient: Gradient {
+                GradientStop { position: 0.2; color: "#dd000000" }
+                GradientStop { position: 0.8; color: "#55000000" }
+                GradientStop { position: 1.0; color: "#00000000" }
+            }
+    }
+
+    Label {
+        id: title
+
+        height: Dims.h(20)
+        anchors.centerIn: parent
+        font {
+            styleName: "SemiCondensed Light"
+            pixelSize: Dims.l(7)
+        }
+        verticalAlignment: Text.AlignVCenter
+        horizontalAlignment: Text.AlignHCenter
+        leftPadding: DeviceInfo.hasRoundScreen ? Dims.w(25) : 0
+        rightPadding: DeviceInfo.hasRoundScreen ? Dims.w(25) : 0
+        wrapMode: Text.WordWrap
+        maximumLineCount: 2
+    }
+}


### PR DESCRIPTION
- Add gradient from near black to transparent behind the title Label to mitigate clipping with of scrolling page content
- Change Fonttype to SemiCondensed Light, to be consistent with the Settings main ListItem
- Add wrapper Item around the rectangle and Label. This makes it necessary to forward the alias for text to the Label.text since some calls of the component assume it is a Label and push the title to the Label.text property.

This requires changes to all pages and apps where PageHeader is used. The PageHeader call needs to be moved last in code order to prevent the text content to scroll on top of the PageHeader. Implementation of this change into the settings pages here https://github.com/AsteroidOS/asteroid-settings/pull/84

Signed-off-by: Timo Könnecke koennecke@mosushi.de

https://user-images.githubusercontent.com/15074193/236313918-fad37852-0c08-4254-b006-3480834c4f4b.mp4

