### PR TITLE
AsteroidApp: Remove extension from filename.

### DIFF
--- a/src/app/asteroidapp.cpp
+++ b/src/app/asteroidapp.cpp
@@ -52,7 +52,7 @@ namespace AsteroidApp {
     QString appName()
     {
         QFileInfo exe = QFileInfo(applicationPath());
-        return exe.fileName();
+        return exe.baseName();
     }
 
     QGuiApplication *application(int &argc, char **argv)


### PR DESCRIPTION
Removes the extension from the filename used to load the application translations.

This is required as otherwise https://github.com/AsteroidOS/asteroid-alarmclock/pull/20 will not work as it tries to load translations with the name `asteroid-flashlight.so.en_GB.qm` instead of `asteroid-flashlight.en_GB.qm`.