### PR TITLE
Remove width from IntSelector label

### DIFF
--- a/src/controls/qml/IntSelector.qml
+++ b/src/controls/qml/IntSelector.qml
@@ -70,7 +70,6 @@ Item {
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
         wrapMode: Text.Wrap
-        width: parent.width * labelWidthRatio
         height: parent.height
     }
 


### PR DESCRIPTION
The recent refactoring removed the former labelWidthRatio property, but the code was still referring to it to set the width of the label in the middle of the IntSelector control.  This fix simply removes the explict width setting because it is implied by the anchors and the widths of the left and right buttons.