### PR TITLE
Change IconButton to inherit MouseArea

### DIFF
--- a/src/controls/qml/IconButton.qml
+++ b/src/controls/qml/IconButton.qml
@@ -19,15 +19,12 @@
 import QtQuick 2.9
 import org.asteroid.controls 1.0
 
-Item {
+MouseArea {
     id: iconButton
-
-    signal clicked()
 
     property color iconColor: "#FFFFFFFF"
     property color pressedIconColor: "#FFFFFFFF"
     property alias iconName: icon.name
-    property alias pressed: mouseArea.containsPress
 
     width: Dims.l(20)
     height: width
@@ -37,13 +34,6 @@ Item {
         name: "ios-circle-outline"
         anchors.fill: parent
         color: pressed ? pressedIconColor : iconColor
-        opacity: mouseArea.containsPress ? 0.7 : 1.0
+        opacity: iconButton.containsPress ? 0.7 : 1.0
     }
-
-    MouseArea {
-        id: mouseArea
-        anchors.fill: parent
-        onClicked: iconButton.clicked()
-    }
-
 }


### PR DESCRIPTION
This should allow all other signals of MouseArea to be easily used by developers and puts IconButton in line with the behaviour of QtQuick Controls Button.
To my understanding, this shouldn't break any existing apps, but I haven't had a chance to test with all apps yet.