### PR TITLE
Make layerstack return pushed item with push()

### DIFF
--- a/src/controls/qml/LayerStack.qml
+++ b/src/controls/qml/LayerStack.qml
@@ -92,6 +92,7 @@ Item {
             if(win !== null)
                 win.setOverridesSystemGestures(layers.length > 0)
             layersChanged();
+            return layer   
         }
     }
 


### PR DESCRIPTION
I thought it would be useful to have a reference to the item pushed to the layerstack. I noticed that quickcontrols' stackview already does this, so this adds this feature to our layerstack.