### PR TITLE
Fix documentation of control classes

### DIFF
--- a/src/controls/qml/CircularSpinner.qml
+++ b/src/controls/qml/CircularSpinner.qml
@@ -31,7 +31,7 @@ import org.asteroid.controls 1.0
 
     \qml
     import QtQuick 2.9
-    import org.controls.asteroid 1.0
+    import org.asteroid.controls 1.0
 
     CircularSpinner {
         id: rating

--- a/src/controls/qml/Dims.qml
+++ b/src/controls/qml/Dims.qml
@@ -41,7 +41,7 @@ pragma Singleton
 
     \qml
     import QtQuick 2.0
-    import org.controls.asteroid 1.0
+    import org.asteroid.controls 1.0
 
     Rectangle {
         width: Dims.w(80) // 80 % of screen width

--- a/src/controls/qml/IconButton.qml
+++ b/src/controls/qml/IconButton.qml
@@ -21,7 +21,7 @@ import org.asteroid.controls 1.0
 
 /*!
     \qmltype IconButton
-    \inqmlmodule org.controls.asteroid 1.0
+    \inqmlmodule org.asteroid.controls 1.0
 
     \brief Provides a virtual button with settable icon.
 

--- a/src/controls/qml/IntSelector.qml
+++ b/src/controls/qml/IntSelector.qml
@@ -40,7 +40,7 @@ import org.asteroid.controls 1.0
 
     \qml
     import QtQuick 2.0
-    import org.controls.asteroid 1.0
+    import org.asteroid.controls 1.0
 
     Item {
         IntSelector {

--- a/src/controls/qml/Label.qml
+++ b/src/controls/qml/Label.qml
@@ -20,7 +20,7 @@ import org.asteroid.controls 1.0
 
 /*!
    \qmltype Label
-   \inqmlmodule org.controls.asteroid 1.0
+   \inqmlmodule org.asteroid.controls 1.0
 
    \brief Provides a way to get a text label sized for AsteroidOS.
 

--- a/src/controls/qml/LabeledActionButton.qml
+++ b/src/controls/qml/LabeledActionButton.qml
@@ -35,7 +35,7 @@ import org.asteroid.controls 1.0
 
     \qml
     import QtQuick 2.0
-    import org.controls.asteroid 1.0
+    import org.asteroid.controls 1.0
 
     Item {
         LabeledActionButton {

--- a/src/controls/qml/LabeledSwitch.qml
+++ b/src/controls/qml/LabeledSwitch.qml
@@ -23,7 +23,7 @@ import org.asteroid.controls 1.0
 
 /*!
     \qmltype LabeledSwitch
-    \inqmlmodule org.controls.asteroid 1.0
+    \inqmlmodule org.asteroid.controls 1.0
 
     \brief This combines \l Label and \l Switch in a convenient package.
 

--- a/src/controls/qml/LayerStack.qml
+++ b/src/controls/qml/LayerStack.qml
@@ -39,7 +39,7 @@ import QtQuick 2.9
 
     \qml
     import QtQuick 2.0
-    import org.controls.asteroid 1.0
+    import org.asteroid.controls 1.0
 
     Item {
         Component {

--- a/src/controls/qml/Marquee.qml
+++ b/src/controls/qml/Marquee.qml
@@ -33,7 +33,7 @@ import org.asteroid.controls 1.0
 
     \qml
     import QtQuick 2.0
-    import org.controls.asteroid 1.0
+    import org.asteroid.controls 1.0
 
     Item {
         Marquee {

--- a/src/controls/qml/PageDot.qml
+++ b/src/controls/qml/PageDot.qml
@@ -36,7 +36,7 @@ import QtQuick 2.9
 
     \qml
     import QtQuick 2.0
-    import org.controls.asteroid 1.0
+    import org.asteroid.controls 1.0
 
     Item {
         IntSelector {

--- a/src/controls/qml/PageHeader.qml
+++ b/src/controls/qml/PageHeader.qml
@@ -22,7 +22,7 @@ import org.asteroid.utils 1.0
 
 /*!
     \qmltype PageHeader
-    \inqmlmodule org.controls.asteroid 1.0
+    \inqmlmodule org.asteroid.controls 1.0
 
     \brief Provides a title on a page.
 

--- a/src/controls/qml/Spinner.qml
+++ b/src/controls/qml/Spinner.qml
@@ -30,7 +30,7 @@ import org.asteroid.controls 1.0
 
     \qml
     import QtQuick 2.0
-    import org.controls.asteroid 1.0
+    import org.asteroid.controls 1.0
 
     Spinner {
         id: rating

--- a/src/controls/qml/StatusPage.qml
+++ b/src/controls/qml/StatusPage.qml
@@ -35,7 +35,7 @@ import org.asteroid.controls 1.0
 
     \qml
     import QtQuick 2.0
-    import org.controls.asteroid 1.0
+    import org.asteroid.controls 1.0
 
     StatusPage {
         text: "On fire"

--- a/src/controls/qml/Switch.qml
+++ b/src/controls/qml/Switch.qml
@@ -21,7 +21,7 @@ import org.asteroid.controls 1.0
 
 /*!
     \qmltype Switch
-    \inqmlmodule org.controls.asteroid 1.0
+    \inqmlmodule org.asteroid.controls 1.0
 
     \brief Specializes \l IconButton to provide an on/off toggle.
 


### PR DESCRIPTION
There was an error in several of the control documentation headers that had org.controls.asteroid instead of org.asteroid.controls.  This only affected the documentation and not how the controls actually work, which is why it hadn't been discovered until now.