### PR TITLE
Rename DeviceInfo to DeviceSpecs to remove conflict

### DIFF
--- a/src/controls/qml/Application.qml
+++ b/src/controls/qml/Application.qml
@@ -101,7 +101,7 @@ Application_p {
         edge: Qt.RightEdge
         visible: false
         z: 10
-        anchors.verticalCenterOffset: DeviceInfo.flatTireHeight/2
+        anchors.verticalCenterOffset: DeviceSpecs.flatTireHeight/2
     }
 
     Indicator {
@@ -109,7 +109,7 @@ Application_p {
         edge: Qt.LeftEdge
         visible: true
         z: 10
-        anchors.verticalCenterOffset: DeviceInfo.flatTireHeight/2
+        anchors.verticalCenterOffset: DeviceSpecs.flatTireHeight/2
     }
 
     Indicator {

--- a/src/controls/qml/BorderGestureArea.qml
+++ b/src/controls/qml/BorderGestureArea.qml
@@ -110,7 +110,7 @@ import org.asteroid.utils 1.0
 MouseArea {
     id: root
 
-    property int boundary: width*DeviceInfo.borderGestureWidth
+    property int boundary: width*DeviceSpecs.borderGestureWidth
     property bool delayReset
 
     signal gestureStarted(string gesture)

--- a/src/controls/qml/Dims.qml
+++ b/src/controls/qml/Dims.qml
@@ -70,7 +70,7 @@ QtObject {
         \brief Returns a dimension that is \a number percent of the screen height.
     */
     function h(number) {
-        return (number/100)*(Screen.desktopAvailableHeight+DeviceInfo.flatTireHeight)
+        return (number/100)*(Screen.desktopAvailableHeight+DeviceSpecs.flatTireHeight)
     }
 
     /*!
@@ -78,7 +78,7 @@ QtObject {
         \brief Returns a dimension that is \a number percent of the screen width or height; whichever is smaller.
     */
     function l(number) {
-        if(Screen.desktopAvailableWidth > (Screen.desktopAvailableHeight+DeviceInfo.flatTireHeight))
+        if(Screen.desktopAvailableWidth > (Screen.desktopAvailableHeight+DeviceSpecs.flatTireHeight))
             return h(number)
         else
             return w(number)

--- a/src/controls/qml/ListItem.qml
+++ b/src/controls/qml/ListItem.qml
@@ -96,7 +96,7 @@ Item {
         anchors {
             verticalCenter: parent.verticalCenter
             left: parent.left
-            leftMargin: DeviceInfo.hasRoundScreen ? Dims.w(18) : Dims.w(12)
+            leftMargin: DeviceSpecs.hasRoundScreen ? Dims.w(18) : Dims.w(12)
         }
     }
 
@@ -104,7 +104,7 @@ Item {
         id: label
 
         anchors {
-            leftMargin: DeviceInfo.hasRoundScreen ? Dims.w(6) : Dims.w(10)
+            leftMargin: DeviceSpecs.hasRoundScreen ? Dims.w(6) : Dims.w(10)
             left: icon.right
             verticalCenter: parent.verticalCenter
         }

--- a/src/controls/qml/PageHeader.qml
+++ b/src/controls/qml/PageHeader.qml
@@ -80,8 +80,8 @@ Item {
         }
         verticalAlignment: Text.AlignVCenter
         horizontalAlignment: Text.AlignHCenter
-        leftPadding: DeviceInfo.hasRoundScreen ? Dims.w(25) : 0
-        rightPadding: DeviceInfo.hasRoundScreen ? Dims.w(25) : 0
+        leftPadding: DeviceSpecs.hasRoundScreen ? Dims.w(25) : 0
+        rightPadding: DeviceSpecs.hasRoundScreen ? Dims.w(25) : 0
         wrapMode: Text.WordWrap
         maximumLineCount: 2
     }

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,11 +1,11 @@
 set(SRC
 	src/utils_plugin.cpp
-	src/deviceinfo.cpp
+	src/devicespecs.cpp
 	src/fileinfo.cpp
 	src/bluetoothstatus.cpp)
 set(HEADERS
 	src/utils_plugin.h
-	src/deviceinfo.h
+	src/devicespecs.h
 	src/fileinfo.h
 	src/bluetoothstatus.h)
 

--- a/src/utils/src/devicespecs.cpp
+++ b/src/utils/src/devicespecs.cpp
@@ -15,14 +15,14 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "deviceinfo.h"
+#include "devicespecs.h"
 #include <QFile>
 
 const char* CONFIG_FILE = "/etc/asteroid/machine.conf";
 const char* HOST_FILE = "/etc/hostname";
 const char* OS_RELEASE_FILE = "/etc/os-release";
 
-DeviceInfo::DeviceInfo()
+DeviceSpecs::DeviceInfo()
     : m_settings(CONFIG_FILE, QSettings::IniFormat)
 {
     QSettings::Status status(m_settings.status());
@@ -57,47 +57,47 @@ DeviceInfo::DeviceInfo()
     }
 }
 
-bool DeviceInfo::hasRoundScreen()
+bool DeviceSpecs::hasRoundScreen()
 {
     return m_settings.value("Display/ROUND", false).toBool();
 }
 
-double DeviceInfo::borderGestureWidth()
+double DeviceSpecs::borderGestureWidth()
 {
     return m_settings.value("Display/BORDER_GESTURE_WIDTH", 0.1).toFloat();
 }
 
-int DeviceInfo::flatTireHeight()
+int DeviceSpecs::flatTireHeight()
 {
     return m_settings.value("Display/FLAT_TIRE", 0).toInt();
 }
 
-bool DeviceInfo::needsBurnInProtection()
+bool DeviceSpecs::needsBurnInProtection()
 {
     return m_settings.value("Display/NEEDS_BURN_IN_PROTECTION", true).toBool();
 }
 
-bool DeviceInfo::hasWlan()
+bool DeviceSpecs::hasWlan()
 {
     return m_settings.value("Capabilities/HAS_WLAN", false).toBool();
 }
 
-bool DeviceInfo::hasSpeaker()
+bool DeviceSpecs::hasSpeaker()
 {
     return m_settings.value("Capabilities/HAS_SPEAKER", false).toBool();
 }
 
-QString DeviceInfo::hostname() const
+QString DeviceSpecs::hostname() const
 {
     return m_hostname;
 }
 
-QString DeviceInfo::machineName() const
+QString DeviceSpecs::machineName() const
 {
     return m_settings.value("Identity/MACHINE", "unknown").toString();
 }
 
-QString DeviceInfo::buildID() const
+QString DeviceSpecs::buildID() const
 {
     return m_buildid;
 }

--- a/src/utils/src/devicespecs.h
+++ b/src/utils/src/devicespecs.h
@@ -23,10 +23,10 @@
 #include <QQmlEngine>
 #include <QSettings>
 
-class DeviceInfo : public QObject
+class DeviceSpecs : public QObject
 {
     Q_OBJECT
-    Q_DISABLE_COPY(DeviceInfo)
+    Q_DISABLE_COPY(DeviceSpecs)
     Q_PROPERTY(bool hasRoundScreen READ hasRoundScreen CONSTANT)
     Q_PROPERTY(double borderGestureWidth READ borderGestureWidth CONSTANT)
     Q_PROPERTY(int flatTireHeight READ flatTireHeight CONSTANT)
@@ -36,14 +36,14 @@ class DeviceInfo : public QObject
     Q_PROPERTY(QString hostname READ hostname CONSTANT)
     Q_PROPERTY(QString machineName READ machineName CONSTANT)
     Q_PROPERTY(QString buildID READ buildID CONSTANT)
-    DeviceInfo();
+    DeviceSpecs();
 public:
     static QObject *qmlInstance(QQmlEngine *engine, QJSEngine *scriptEngine)
     {
         Q_UNUSED(engine);
         Q_UNUSED(scriptEngine);
 
-        return new DeviceInfo;
+        return new DeviceSpecs;
     }
     bool hasRoundScreen();
     double borderGestureWidth();

--- a/src/utils/src/utils_plugin.cpp
+++ b/src/utils/src/utils_plugin.cpp
@@ -18,7 +18,7 @@
 #include "utils_plugin.h"
 #include <QtQml>
 #include "bluetoothstatus.h"
-#include "deviceinfo.h"
+#include "devicespecs.h"
 #include "fileinfo.h"
 
 UtilsPlugin::UtilsPlugin(QObject *parent) : QQmlExtensionPlugin(parent)
@@ -29,7 +29,7 @@ void UtilsPlugin::registerTypes(const char *uri)
 {
     Q_ASSERT(uri == QLatin1String("org.asteroid.utils"));
 
-    qmlRegisterSingletonType<DeviceInfo>(uri, 1,0, "DeviceInfo", &DeviceInfo::qmlInstance);
+    qmlRegisterSingletonType<DeviceSpecs>(uri, 1,0, "DeviceInfo", &DeviceInfo::qmlInstance);
     qmlRegisterSingletonType<FileInfo>(uri, 1, 0, "FileInfo", &FileInfo::qmlInstance);
     qmlRegisterType<BluetoothStatus>(uri, 1, 0, "BluetoothStatus");
 }


### PR DESCRIPTION
This renames the DeviceInfo QML class in org.asteroid.utils to DeviceSpecs to avoid a conflict with an unrelated DeviceInfo class defined in org.nemomobile.systemsettings.

This fixes https://github.com/AsteroidOS/qml-asteroid/issues/56