### PR TITLE
Fix shader compatibility for desktop OpenGL

### DIFF
--- a/src/controls/qml/CircularSpinner.qml
+++ b/src/controls/qml/CircularSpinner.qml
@@ -94,8 +94,15 @@ PathView {
     layer.enabled: true
     layer.effect: ShaderEffect {
         fragmentShader: "
-        precision mediump float;
-        varying highp vec2 qt_TexCoord0;
+        #ifdef GL_ES
+            precision mediump float;
+            varying highp vec2 qt_TexCoord0;
+        #else
+            #define highp
+            #define mediump
+            #define lowp
+            varying vec2 qt_TexCoord0;
+        #endif
         uniform sampler2D source;
         void main(void)
         {

--- a/src/controls/qml/Spinner.qml
+++ b/src/controls/qml/Spinner.qml
@@ -73,8 +73,15 @@ ListView {
     layer.enabled: true
     layer.effect: ShaderEffect {
         fragmentShader: "
-        precision mediump float;
-        varying highp vec2 qt_TexCoord0;
+        #ifdef GL_ES
+            precision mediump float;
+            varying highp vec2 qt_TexCoord0;
+        #else
+            #define highp
+            #define mediump
+            #define lowp
+            varying vec2 qt_TexCoord0;
+        #endif
         uniform sampler2D source;
         void main(void)
         {


### PR DESCRIPTION
This fixes issue #55 by detecting whether GL_ES is defined or not within the shaders for Spinner and CircularSpinner and using the appropriate defines to get the same effect on desktop as on the watch.