### PR TITLE
Improve CircularSpinner drag precision

### DIFF
--- a/src/controls/qml/CircularSpinner.qml
+++ b/src/controls/qml/CircularSpinner.qml
@@ -15,7 +15,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
+import QtQuick 2.15
 import org.asteroid.controls 1.0
 
 /*!
@@ -30,7 +30,7 @@ import org.asteroid.controls 1.0
     to two digits.  This is particularly convenient for setting times and dates
 
     \qml
-    import QtQuick 2.9
+    import QtQuick 2.15
     import org.asteroid.controls 1.0
 
     CircularSpinner {
@@ -72,6 +72,8 @@ PathView {
     preferredHighlightEnd: 0.5
     highlightRangeMode: PathView.StrictlyEnforceRange
     highlightMoveDuration: 0
+    snapMode: PathView.SnapToItem
+    dragMargin: width/2
     clip: true
 
     delegate: SpinnerDelegate { }

--- a/src/controls/qml/Spinner.qml
+++ b/src/controls/qml/Spinner.qml
@@ -15,7 +15,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.9
+import QtQuick 2.15
 import org.asteroid.controls 1.0
 
 


### PR DESCRIPTION
Both spinner components were importing QtQuick 2.9 despite the project targeting Qt 5.15. This aligns them with the rest of the codebase.

CircularSpinner gains two improvements discovered during a drag precision investigation: snapMode: PathView.SnapToItem enables proper per-item snapping, and dragMargin: 50 extends the touch target beyond the text glyph to the full column width. The latter fixes the core UX issue where short numeric strings (hours, minutes) were difficult to drag precisely because the interactive area was limited to the glyph size rather than the column width.

Tested on catfish, beluga and rubyfish.