### PR TITLE
Fix for qt5

### DIFF
--- a/src/controls/CMakeLists.txt
+++ b/src/controls/CMakeLists.txt
@@ -22,9 +22,7 @@ else()
                 src/flatmeshgeometry.h)
 endif()
 
-add_library(asteroidcontrolsplugin ${SRC} ${HEADERS})
-
-set(controls 
+set(controls
         Application
         BorderGestureArea
         CircularSpinner
@@ -58,18 +56,21 @@ set(controls
 )
 if (${QT_VERSION_MAJOR} EQUAL 6)
         set(controls ${controls} ValueMeter_qt6)
+        foreach(control ${controls})
+                list(APPEND controls-qml "qml/${control}.qml")
+        endforeach()
+
+        add_library(asteroidcontrolsplugin ${SRC} ${HEADERS})
+        qt_add_resources(
+                asteroidcontrolsplugin "asteroidcontrolsplugin_qrc"
+                PREFIX "/org/asteroid/controls/"
+                FILES "${controls-qml}"
+        )
 else()
         set(controls ${controls} ValueMeter)
+        add_library(asteroidcontrolsplugin ${SRC} ${HEADERS} resources.qrc)
 endif()
-foreach(control ${controls})
-        list(APPEND controls-qml "qml/${control}.qml")
-endforeach()
 
-qt_add_resources(
-        asteroidcontrolsplugin "asteroidcontrolsplugin_qrc"
-        PREFIX "/org/asteroid/controls/"
-        FILES "${controls-qml}"
-)
 
 set(controls-docs "$<LIST:TRANSFORM,$<LIST:TRANSFORM,$<LOWER_CASE:${controls}>,PREPEND,qml->,APPEND,.html>")
 set(doc-dir "${CMAKE_BINARY_DIR}/doc/html")

--- a/src/controls/qml/LabeledActionButton.qml
+++ b/src/controls/qml/LabeledActionButton.qml
@@ -55,7 +55,7 @@ ListRow {
 
     Connections {
         target: actionArea
-        onStatusChanged: {
+        function onStatusChanged() {
             if (actionArea.status === Loader.Ready)
                 actionArea.item.name = Qt.binding(function() { return icon })
         }

--- a/src/controls/qml/LabeledSwitch.qml
+++ b/src/controls/qml/LabeledSwitch.qml
@@ -71,7 +71,7 @@ ListRow {
 
     Connections {
         target: actionArea
-        onStatusChanged: {
+        function onStatusChanged() {
             if (actionArea.status === Loader.Ready)
                 actionArea.item.checked = Qt.binding(function() { return checked })
         }

--- a/src/controls/qml/OptionCycler.qml
+++ b/src/controls/qml/OptionCycler.qml
@@ -47,6 +47,8 @@ import org.asteroid.controls 1.0
     \endqml
 */
 ListRow {
+    id: root
+    property alias text: root.text
     /*!
         \qmlproperty var OptionCycler::valueArray
         The array of values to cycle through.

--- a/src/controls/qml/OptionCycler.qml
+++ b/src/controls/qml/OptionCycler.qml
@@ -80,7 +80,7 @@ ListRow {
 
     Connections {
         target: actionArea
-        onStatusChanged: {
+        function onStatusChanged() {
             if (actionArea.status === Loader.Ready)
                 actionArea.item.text = Qt.binding(function() { return currentValue })
         }

--- a/src/controls/resources.qrc
+++ b/src/controls/resources.qrc
@@ -1,0 +1,35 @@
+<RCC>
+    <qresource prefix="/org/asteroid/controls/">
+        <file>qml/Application.qml</file>
+        <file>qml/BorderGestureArea.qml</file>
+        <file>qml/CircularSpinner.qml</file>
+        <file>qml/Dims.qml</file>
+        <file>qml/HandWritingKeyboard.qml</file>
+        <file>qml/HighlightBar.qml</file>
+        <file>qml/IconButton.qml</file>
+        <file>qml/Indicator.qml</file>
+        <file>qml/IntSelector.qml</file>
+        <file>qml/Label.qml</file>
+        <file>qml/LabeledActionButton.qml</file>
+        <file>qml/LabeledSwitch.qml</file>
+        <file>qml/LayerStack.qml</file>
+        <file>qml/ListItem.qml</file>
+        <file>qml/ListRow.qml</file>
+        <file>qml/Marquee.qml</file>
+        <file>qml/OptionCycler.qml</file>
+        <file>qml/PageDot.qml</file>
+        <file>qml/PageHeader.qml</file>
+        <file>qml/Particle.qml</file>
+        <file>qml/RemorseTimer.qml</file>
+        <file>qml/RowSeparator.qml</file>
+        <file>qml/SegmentedArc.qml</file>
+        <file>qml/Spinner.qml</file>
+        <file>qml/SpinnerDelegate.qml</file>
+        <file>qml/StatusPage.qml</file>
+        <file>qml/Switch.qml</file>
+        <file>qml/TextArea.qml</file>
+        <file>qml/TextBase.qml</file>
+        <file>qml/TextField.qml</file>
+        <file>qml/ValueMeter.qml</file>
+    </qresource>
+</RCC>


### PR DESCRIPTION
Several factors prevent the current master branch from working on Qt5 cleanly.  They are:

1. the CMakeLists.txt file incorrectly creates the library on Qt5.
2. implicitly defined onFoo properties in Connections are deprecated
3. OptionCycler's text property was not correctly exported

With these changes, we can build and successfully run the Settings app on watches such as `sturgeon` and `catfish` with the existing Qt 5.15.
