### PR TITLE
Fix icon rendering pixelation on Qt6 by removing deprecated FBO render target

### DIFF
--- a/src/controls/src/icon.cpp
+++ b/src/controls/src/icon.cpp
@@ -39,7 +39,6 @@
 Icon::Icon()
 {
     setFlag(ItemHasContents, true);
-    setRenderTarget(QQuickPaintedItem::FramebufferObject);
     m_color = Qt::white;
 }
 


### PR DESCRIPTION
- Remove setRenderTarget(QQuickPaintedItem::FramebufferObject) from Icon constructor: this render target was deprecated in Qt6 and its coordinate system behavior changed, causing the QPainter in paint() to operate at half the expected resolution, making each rendered pixel appear as two physical display pixels

Before:

<img width="801" height="555" alt="image" src="https://github.com/user-attachments/assets/b6b772aa-331d-4940-9ac3-34c47b447255" />

After:

<img width="548" height="459" alt="image" src="https://github.com/user-attachments/assets/d05c0f8f-b252-4e3a-9fdc-f566c1bd84e7" />
