### PR TITLE
Qt6 injection fixes

### DIFF
--- a/src/controls/qml/IntSelector.qml
+++ b/src/controls/qml/IntSelector.qml
@@ -219,7 +219,7 @@ ListRow {
                 tracking = false
             }
 
-            onPositionChanged: {
+            onPositionChanged: (mouse) => {
                 if (!tracking) {
                     var dx = Math.abs(mouseX - startX)
                     var dy = Math.abs(mouseY - startY)

--- a/src/controls/qml/LayerStack.qml
+++ b/src/controls/qml/LayerStack.qml
@@ -188,15 +188,15 @@ Item {
 
         property real swipeThreshold: 0.15
 
-        onGestureStarted: {
+        onGestureStarted: (gesture) => {
             swipeAnimation.stop()
             cancelAnimation.stop()
-            if(gesture == "right")
+            if (gesture == "right")
                 state = "swipe"
         }
 
-        onGestureFinished: {
-            if(gesture == "right") {
+        onGestureFinished: (gesture) => {
+            if (gesture == "right") {
                 if (gestureArea.progress >= swipeThreshold) {
                     swipeAnimation.valueTo = width
                     swipeAnimation.start()


### PR DESCRIPTION
This fixes Qt6 signal parameter injection deprecation warnings in LayerStack.qml and IntSelector.qml.

Qt6 deprecated implicit injection of signal parameters into handler bodies. Handlers that reference signal-provided objects must now use arrow function syntax with explicit parameter declarations.

LayerStack.qml: onGestureStarted and onGestureFinished reference the gesture parameter from BorderGestureArea signals.

IntSelector.qml: onPositionChanged references mouse.accepted to reject non-horizontal drag events. mouseX and mouseY are MouseArea properties and required no change.

Tested on sparrow with QuickPanel drag reordering and IntSelector brightness scrubbing confirming log messages are gone and no observed regressions.