### PR TITLE
fix(cmake): use KDE_INSTALL_QMLDIR to determine QML module installation location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(qml-asteroid
 	DESCRIPTION "QML components, styles and demos for AsteroidOS"
 )
 
-find_package(ECM REQUIRED NO_MODULE)
+find_package(ECM 6.0.0 REQUIRED NO_MODULE)
 
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
 
@@ -14,6 +14,7 @@ option(WITH_CMAKE_MODULES "Install AsteroidOS CMake modules" ON)
 
 include(FeatureSummary)
 include(GNUInstallDirs)
+include(KDEInstallDirs)
 include(ECMFindQmlModule)
 include(ECMGeneratePkgConfigFile)
 include(Asteroid6CMakeSettings)
@@ -40,7 +41,6 @@ else()
                         OUTPUT_VARIABLE QT_INSTALL_QML
                         ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
     endif()
-    set(INSTALL_QML_IMPORT_DIR ${QT_INSTALL_QML})
 endif()
 
 add_subdirectory(src)

--- a/cmake/Asteroid6CMakeSettings.cmake
+++ b/cmake/Asteroid6CMakeSettings.cmake
@@ -31,8 +31,5 @@ if (NOT ASTEROID_SKIP_BUILD_SETTINGS)
 	# Since CMake 3.0
 	set(CMAKE_AUTORCC ON)
 
-	set(INSTALL_QML_IMPORT_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/qml" 
-		CACHE PATH "Custom QML import installation directory")
-
 	set(QT_MIN_VERSION "6.10.0")
 endif()

--- a/src/controls/CMakeLists.txt
+++ b/src/controls/CMakeLists.txt
@@ -89,9 +89,9 @@ target_link_libraries(
 
 install(
     TARGETS asteroidcontrolsplugin
-    DESTINATION ${INSTALL_QML_IMPORT_DIR}/org/asteroid/controls
+    DESTINATION ${KDE_INSTALL_QMLDIR}/org/asteroid/controls
 )
 install(
     FILES qmldir
-    DESTINATION ${INSTALL_QML_IMPORT_DIR}/org/asteroid/controls
+    DESTINATION ${KDE_INSTALL_QMLDIR}/org/asteroid/controls
 )

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -17,6 +17,6 @@ target_link_libraries(asteroidutilsplugin
 	Qt::Quick)
 
 install(TARGETS asteroidutilsplugin
-	DESTINATION ${INSTALL_QML_IMPORT_DIR}/org/asteroid/utils)
+	DESTINATION ${KDE_INSTALL_QMLDIR}/org/asteroid/utils)
 install(FILES qmldir
-	DESTINATION ${INSTALL_QML_IMPORT_DIR}/org/asteroid/utils)
+	DESTINATION ${KDE_INSTALL_QMLDIR}/org/asteroid/utils)


### PR DESCRIPTION
Saves the packager from manually defining INSTALL_QML_IMPORT_DIR