### PR TITLE
cmake: Find the GuiPrivate package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ include(Asteroid6CMakeSettings)
 set(ASTEROID_MODULES_INSTALL_DIR ${CMAKE_INSTALL_DATADIR}/asteroidapp/cmake)
 
 set(QT_MIN_VERSION "6.10.0")
-find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED DBus Gui Qml Quick Svg ShaderTools WaylandClient)
+find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED DBus Gui GuiPrivate Qml Quick Svg ShaderTools WaylandClient)
 find_package(Qt6WaylandScannerTools ${QT_MIN_VERSION} CONFIG REQUIRED)
 ecm_find_qmlmodule(Qt5Compat.GraphicalEffects 1.0)
 ecm_find_qmlmodule(QtQuick.VirtualKeyboard 2.1)


### PR DESCRIPTION
This fixes this issue:
```
 CMake Error at src/controls/CMakeLists.txt:89 (target_link_libraries):
|   Target "asteroidcontrolsplugin" links to:
|
|     Qt::GuiPrivate
|
|   but the target was not found.  Possible reasons include:
|
|     * There is a typo in the target name.
|     * A find_package call is missing for an IMPORTED target.
|     * An ALIAS target is missing.
|
```