### PR TITLE
FlatMesh: give each node its own animation timer

### DIFF
--- a/src/controls/src/flatmeshnode.cpp
+++ b/src/controls/src/flatmeshnode.cpp
@@ -121,15 +121,14 @@ void FlatMeshNode::setAnimated(bool animated)
 
 void FlatMeshNode::maybeAnimate()
 {
-    static QElapsedTimer t;
     bool firstFrame = false;
-    if(!t.isValid()) {
-        t.start();
+    if(!m_animTimer.isValid()) {
+        m_animTimer.start();
         firstFrame = true;
     }
 
-    if (firstFrame || (m_animated && t.elapsed() >= 80)) {
-        t.restart();
+    if (firstFrame || (m_animated && m_animTimer.elapsed() >= 80)) {
+        m_animTimer.restart();
         m_animationState += 0.02f;
 
         float shiftMix = m_animationState;

--- a/src/controls/src/flatmeshnode.h
+++ b/src/controls/src/flatmeshnode.h
@@ -33,6 +33,7 @@
 #include <QObject>
 #include <QQuickWindow>
 #include <QSGSimpleRectNode>
+#include <QElapsedTimer>
 
 #define NUM_POINTS_X 13
 #define NUM_POINTS_Y 13
@@ -73,6 +74,7 @@ private:
     QQuickWindow *m_window;
     int m_loopCount;
     float m_screenScaleFactor;
+    QElapsedTimer m_animTimer;
     Point m_points[NUM_POINTS_X*NUM_POINTS_Y];
 };
 


### PR DESCRIPTION
Every FlatMeshNode connected maybeAnimate() to the same window afterRendering() signal but throttled geometry recomputation with a function-local "static QElapsedTimer". Whichever node ran first each frame restarted the shared timer, so the remaining nodes always saw elapsed < 80ms and skipped computing their triangle vertices, leaving their geometry degenerate and the mesh fully transparent for its whole lifetime.

This only bites when two or more FlatMeshes are alive at once - most visibly at first run, where the wallpaper FlatMesh and the FirstRunConfig FlatMesh coexist: depending on node creation/connection order the language page would render see-through, exposing the Tutorial and home screen behind it on some boots but not others.

Make the throttle timer a per-instance member so each node fills its own geometry on its first frame and animates independently.