### PR TITLE
Application.qml: flatmesh offset for flat tire displays

### DIFF
--- a/src/controls/qml/Application.qml
+++ b/src/controls/qml/Application.qml
@@ -77,6 +77,7 @@ Application_p {
     FlatMesh {
         id: fm
         anchors.fill: parent
+        anchors.bottomMargin: -DeviceSpecs.flatTireHeight
     }
 
     /*!


### PR DESCRIPTION
Recent changes to flatmesh result make it circular, but the quirks of flat tire devices result in it appearing as oval. Add flat tire offset so that flatmesh appears circular and fills the whole screen on flat tire displays

fixes #112 . A similar issue is already fixed in a similar way in the launcher (the whole launcher is made to fill the 'visual circle' of the flat tire display).