### PR TITLE
HighlightBar: Make MouseArea root

### DIFF
--- a/src/controls/qml/HighlightBar.qml
+++ b/src/controls/qml/HighlightBar.qml
@@ -72,28 +72,23 @@ import org.asteroid.controls
     }
     \endqml
 */
-Rectangle {
-    /*! forward the clicked() signal to parent */
-    signal clicked()
+MouseArea {
     /*! alias to receive boolean forceOn to act like a controlled radio button */
     property bool forceOn: false
 
+    hoverEnabled: true
+
     anchors.fill: parent
-    /*! the default color may be overridden */
-    color: rowClick.containsPress || forceOn ? "#33ffffff" : "#00ffffff"
 
-    Behavior on color {
-        ColorAnimation {
-            duration: 150;
-            easing.type: Easing.OutQuad
-        }
-    }
-
-    MouseArea {
-        id: rowClick
-
+    Rectangle {
+        id: highlight
         anchors.fill: parent
-        hoverEnabled: true
-        onClicked: parent.clicked()
+        color: parent.containsPress || parent.forceOn ? "#33ffffff" : "#00ffffff"
+        Behavior on color {
+            ColorAnimation {
+                duration: 150;
+                easing.type: Easing.OutQuad
+            }
+        }
     }
 }

--- a/src/controls/qml/HighlightBar.qml
+++ b/src/controls/qml/HighlightBar.qml
@@ -76,6 +76,10 @@ MouseArea {
     /*! alias to receive boolean forceOn to act like a controlled radio button */
     property bool forceOn: false
 
+    property color activeColor: "#33ffffff"
+    property color inactiveColor: "#00ffffff"
+    property alias color: highlight.color
+
     hoverEnabled: true
 
     anchors.fill: parent
@@ -83,7 +87,7 @@ MouseArea {
     Rectangle {
         id: highlight
         anchors.fill: parent
-        color: parent.containsPress || parent.forceOn ? "#33ffffff" : "#00ffffff"
+        color: parent.containsPress || parent.forceOn ? parent.activeColor : parent.inactiveColor
         Behavior on color {
             ColorAnimation {
                 duration: 150;


### PR DESCRIPTION
This swaps the `MouseArea` to be the root of the `HighlightBar`
This enables the usage of more complex behaviours with the `MouseArea`'s signals. Previously, `HighlightBar` had a `clicked` signal, but it doesn't pass any of the event details that the `MouseArea`'s `clicked` signal emits. The `MouseArea`'s clicked signal was also always handled - this means that the `MouseArea` would 'steal' clicks from any items below it, even if it wasn't doing anything.
I tried to make this change in the least invasive way possible.
Tested against asteroid-settings, there don't seem to be any regressions